### PR TITLE
Add the en_US.UTF-8 locale to the CI environments

### DIFF
--- a/Dockerfile.bionic
+++ b/Dockerfile.bionic
@@ -3,6 +3,10 @@ ARG         DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get -y dist-upgrade
 
+RUN apt-get install --yes --no-install-recommends locales && \
+    sed -i -e "s/^#\s*en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/" /etc/locale.gen && \
+    locale-gen
+
 RUN apt-get update && apt-get install --yes --no-install-recommends \
   adduser \
   build-essential \

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -3,6 +3,10 @@ ARG         DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get -y dist-upgrade
 
+RUN apt-get install --yes --no-install-recommends locales && \
+    sed -i -e "s/^#\s*en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/" /etc/locale.gen && \
+    locale-gen
+
 RUN apt-get update && apt-get install --yes --no-install-recommends \
   adduser \
   build-essential \

--- a/Dockerfile.debian-testing
+++ b/Dockerfile.debian-testing
@@ -3,6 +3,10 @@ ARG         DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get -y dist-upgrade
 
+RUN apt-get install --yes --no-install-recommends locales && \
+    sed -i -e "s/^#\s*en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/" /etc/locale.gen && \
+    locale-gen
+
 RUN apt-get update && apt-get install --yes --no-install-recommends \
   adduser \
   build-essential \

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -3,6 +3,10 @@ ARG         DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get -y dist-upgrade
 
+RUN apt-get install --yes --no-install-recommends locales && \
+    sed -i -e "s/^#\s*en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/" /etc/locale.gen && \
+    locale-gen
+
 RUN apt-get update && apt-get install --yes --no-install-recommends \
   adduser \
   build-essential \


### PR DESCRIPTION
In preparation to use en_US.UTF-8 as the required build locale for the entire Ganeti build process (and not just parts of it) the CI containers need to support this locale.
