### PR TITLE
Add bookworm Dockerfile, debian-testing is now trixie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image-name: [bullseye, debian-testing, focal, jammy]
+        image-name: [bookworm, debian-testing, focal, jammy]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 ARG         DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get -y dist-upgrade
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   build-essential \
   automake \
   pandoc \
-  python-all \
+  python3-all \
   git \
   ghc \
   ghc-ghci \
@@ -38,8 +38,6 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   libghc-test-framework-hunit-dev \
   libghc-temporary-dev \
   libghc-old-time-dev \
-  libpcre3-dev \
-  libcurl4-openssl-dev \
   python3-bitarray \
   python3-mock \
   python3-openssl \


### PR DESCRIPTION
With the release of Debian Bookworm we can drop the support for Debian Bullseye. This commit drops the Bullseye config, adds a Bookworm config and debian-testing does not need to change.