### PR TITLE
add python3-pip,python3-black & pylint for dev or CI environments

### DIFF
--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -38,6 +38,8 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   libghc-test-framework-hunit-dev \
   libghc-temporary-dev \
   libghc-old-time-dev \
+  black \
+  pylint \
   python3-bitarray \
   python3-mock \
   python3-openssl \

--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -48,6 +48,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   python3-simplejson \
   python3-sphinx \
   python3-yaml \
+  python3-pip \
   graphviz \
   openssh-client \
   procps \

--- a/Dockerfile.debian-testing
+++ b/Dockerfile.debian-testing
@@ -38,6 +38,8 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   libghc-test-framework-hunit-dev \
   libghc-temporary-dev \
   libghc-old-time-dev \
+  black \
+  pylint \
   python3-bitarray \
   python3-mock \
   python3-openssl \

--- a/Dockerfile.debian-testing
+++ b/Dockerfile.debian-testing
@@ -48,6 +48,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   python3-simplejson \
   python3-sphinx \
   python3-yaml \
+  python3-pip \
   graphviz \
   openssh-client \
   procps \

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -40,6 +40,8 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   libghc-old-time-dev \
   libpcre3-dev \
   libcurl4-openssl-dev \
+  black \
+  pylint \
   python3-bitarray \
   python3-mock \
   python3-openssl \

--- a/Dockerfile.focal
+++ b/Dockerfile.focal
@@ -50,6 +50,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   python3-simplejson \
   python3-sphinx \
   python3-yaml \
+  python3-pip \
   graphviz \
   openssh-client \
   procps \

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -40,6 +40,8 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   libghc-old-time-dev \
   libpcre3-dev \
   libcurl4-openssl-dev \
+  black \
+  pylint \
   python3-bitarray \
   python3-mock \
   python3-openssl \

--- a/Dockerfile.jammy
+++ b/Dockerfile.jammy
@@ -50,6 +50,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   python3-simplejson \
   python3-sphinx \
   python3-yaml \
+  python3-pip \
   graphviz \
   openssh-client \
   procps \


### PR DESCRIPTION
This PR adds the python3-pip package to install Python tools for development in the CI image in the future. 
With pip, linters such as flake8, pylint or formatters such as black could be installed in the CI-container.