### PR TITLE
add Haskell lib for regex-tdfa

### DIFF
--- a/ganeti/Dockerfile.bookworm
+++ b/ganeti/Dockerfile.bookworm
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   libghc-base64-bytestring-dev \
   libghc-zlib-dev \
   libghc-regex-pcre-dev \
+  libghc-regex-tdfa-dev \
   libghc-attoparsec-dev \
   libghc-vector-dev \
   libghc-lifted-base-dev \

--- a/ganeti/Dockerfile.debian-testing
+++ b/ganeti/Dockerfile.debian-testing
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   libghc-hinotify-dev \
   libghc-base64-bytestring-dev \
   libghc-zlib-dev \
-  libghc-regex-pcre-dev \
+  libghc-regex-tdfa-dev \
   libghc-attoparsec-dev \
   libghc-vector-dev \
   libghc-lifted-base-dev \

--- a/ganeti/Dockerfile.focal
+++ b/ganeti/Dockerfile.focal
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   libghc-base64-bytestring-dev \
   libghc-zlib-dev \
   libghc-regex-pcre-dev \
+  libghc-regex-tdfa-dev \
   libghc-attoparsec-dev \
   libghc-vector-dev \
   libghc-lifted-base-dev \

--- a/ganeti/Dockerfile.jammy
+++ b/ganeti/Dockerfile.jammy
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   libghc-base64-bytestring-dev \
   libghc-zlib-dev \
   libghc-regex-pcre-dev \
+  libghc-regex-tdfa-dev \
   libghc-attoparsec-dev \
   libghc-vector-dev \
   libghc-lifted-base-dev \

--- a/ganeti/Dockerfile.noble
+++ b/ganeti/Dockerfile.noble
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get install --yes --no-install-recommends \
   libghc-base64-bytestring-dev \
   libghc-zlib-dev \
   libghc-regex-pcre-dev \
+  libghc-regex-tdfa-dev \
   libghc-attoparsec-dev \
   libghc-vector-dev \
   libghc-lifted-base-dev \


### PR DESCRIPTION
Recently regex-pcre is no longer available in Debian testing (Trixie) and an alternative regex-tdfa has been implemented, but at the coast of losing PCRE regex in favor of POSIX. Adding regex-tdfa to the CI images and removing regex-pcre from Debian testing to be able for testing as much as possible.